### PR TITLE
Fix hero section titleText sizing on smaller screens

### DIFF
--- a/src/pages/Home/components/Banner/index.module.css
+++ b/src/pages/Home/components/Banner/index.module.css
@@ -68,6 +68,36 @@
   opacity: 0.8;
 }
 
+@media (max-width: 1180px) {
+  .banner {
+    flex-direction: column;
+    padding: 32px 24px;
+    min-height: auto;
+    gap: 20px;
+  }
+
+  .titleText {
+    text-align: center;
+    font-size: 42px;
+    line-height: 1.1;
+  }
+
+  .descriptionText {
+    width: 80vw;
+    margin-top: 8px;
+  }
+
+  .buttonContainer {
+    margin-top: 24px;
+  }
+
+  .icon {
+    margin-right: 0;
+    width: 320px;
+    height: 320px;
+  }
+}
+
 @media (max-width: 767.99px) {
   .descriptionText {
     width: 90vw;


### PR DESCRIPTION
## Problem
- The hero section title text was not centered on smaller screens.
- The title text had extra spacing on smaller screens.

## What Changed
- Fixed the title text sizing and alignment for smaller screen sizes.

## Screenshots
| Before | After |
| ------ | ----- |
|<img width="408" height="659" alt="Screenshot 2026-01-29 130930" src="https://github.com/user-attachments/assets/2dd7d3c9-ab28-4673-9507-df67f68f4973" />|<img width="404" height="587" alt="Screenshot 2026-01-29 130923" src="https://github.com/user-attachments/assets/07be9fae-938d-4da7-9f88-2c0aafbc955a" />|
|<img width="1038" height="537" alt="Screenshot 2026-01-29 131042" src="https://github.com/user-attachments/assets/d1f52983-82d2-4176-8bba-5b45c14edf91" />|<img width="1038" height="657" alt="Screenshot 2026-01-29 131052" src="https://github.com/user-attachments/assets/7896adbd-f2cb-4740-96fa-af8a5f5bcc99" />|